### PR TITLE
feat: add Windows GUI tool for Claude Desktop MCP configuration

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,10 +20,15 @@ jobs:
       with:
         go-version: '1.21'
     
-    - name: Build Windows executable
+    - name: Build Windows executables
       run: |
+        mkdir -p dist
+        # Build sample app
         GOOS=windows GOARCH=amd64 go build -o dist/app-windows-amd64.exe ./cmd/main.go
         GOOS=windows GOARCH=386 go build -o dist/app-windows-386.exe ./cmd/main.go
+        # Build Claude Desktop config tool
+        GOOS=windows GOARCH=amd64 go build -ldflags="-H windowsgui" -o dist/claude-config-windows-amd64.exe ./cmd/claude-config/main.go
+        GOOS=windows GOARCH=386 go build -ldflags="-H windowsgui" -o dist/claude-config-windows-386.exe ./cmd/claude-config/main.go
     
     - name: Upload Windows artifacts
       uses: actions/upload-artifact@v4
@@ -32,6 +37,8 @@ jobs:
         path: |
           dist/app-windows-amd64.exe
           dist/app-windows-386.exe
+          dist/claude-config-windows-amd64.exe
+          dist/claude-config-windows-386.exe
         retention-days: 30
 
   build-multi-platform:
@@ -67,11 +74,16 @@ jobs:
     - name: Build executable
       run: |
         mkdir -p dist
+        # Build sample app
         GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w" -o dist/app-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/main.go
+        # Build Claude config tool (Windows only with GUI flag)
+        if [ "${{ matrix.goos }}" = "windows" ]; then
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -ldflags="-s -w -H windowsgui" -o dist/claude-config-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }} ./cmd/claude-config/main.go
+        fi
     
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:
         name: app-${{ matrix.goos }}-${{ matrix.goarch }}
-        path: dist/app-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+        path: dist/*-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
         retention-days: 30

--- a/cmd/claude-config/main.go
+++ b/cmd/claude-config/main.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/lxn/walk"
+	. "github.com/lxn/walk/declarative"
+)
+
+type McpServer struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+type ClaudeConfig struct {
+	McpServers map[string]McpServer `json:"mcpServers"`
+}
+
+type MainWindow struct {
+	*walk.MainWindow
+	rplsCheckBox    *walk.CheckBox
+	queenitCheckBox *walk.CheckBox
+	statusLabel     *walk.Label
+}
+
+func getClaudeConfigPath() string {
+	if runtime.GOOS == "windows" {
+		appData := os.Getenv("APPDATA")
+		if appData == "" {
+			homeDir, _ := os.UserHomeDir()
+			appData = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+		return filepath.Join(appData, "Claude", "claude_desktop_config.json")
+	}
+	// For other platforms (fallback)
+	homeDir, _ := os.UserHomeDir()
+	return filepath.Join(homeDir, "Library", "Application Support", "Claude", "claude_desktop_config.json")
+}
+
+func loadExistingConfig() (*ClaudeConfig, error) {
+	configPath := getClaudeConfigPath()
+	
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return &ClaudeConfig{McpServers: make(map[string]McpServer)}, nil
+	}
+
+	data, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var config ClaudeConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	if config.McpServers == nil {
+		config.McpServers = make(map[string]McpServer)
+	}
+
+	return &config, nil
+}
+
+func saveConfig(config *ClaudeConfig) error {
+	configPath := getClaudeConfigPath()
+	
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(configPath, data, 0644)
+}
+
+func (mw *MainWindow) updateConfig() {
+	config, err := loadExistingConfig()
+	if err != nil {
+		mw.statusLabel.SetText(fmt.Sprintf("Error loading config: %v", err))
+		return
+	}
+
+	// Handle RPLS checkbox
+	if mw.rplsCheckBox.Checked() {
+		config.McpServers["rpls"] = McpServer{
+			Command: "npx",
+			Args:    []string{"mcp-remote", "https://agentgateway.damoa.rapportlabs.dance/mcp"},
+		}
+	} else {
+		delete(config.McpServers, "rpls")
+	}
+
+	// Handle Queenit checkbox
+	if mw.queenitCheckBox.Checked() {
+		config.McpServers["queenit"] = McpServer{
+			Command: "npx",
+			Args:    []string{"mcp-remote", "https://mcp.rapportlabs.kr/mcp"},
+		}
+	} else {
+		delete(config.McpServers, "queenit")
+	}
+
+	if err := saveConfig(config); err != nil {
+		mw.statusLabel.SetText(fmt.Sprintf("Error saving config: %v", err))
+		return
+	}
+
+	mw.statusLabel.SetText("Configuration updated successfully! Please restart Claude Desktop.")
+}
+
+func (mw *MainWindow) loadCurrentState() {
+	config, err := loadExistingConfig()
+	if err != nil {
+		mw.statusLabel.SetText(fmt.Sprintf("Error loading current config: %v", err))
+		return
+	}
+
+	// Set checkbox states based on current config
+	_, rplsExists := config.McpServers["rpls"]
+	mw.rplsCheckBox.SetChecked(rplsExists)
+
+	_, queenitExists := config.McpServers["queenit"]
+	mw.queenitCheckBox.SetChecked(queenitExists)
+
+	configPath := getClaudeConfigPath()
+	mw.statusLabel.SetText(fmt.Sprintf("Config file: %s", configPath))
+}
+
+func main() {
+	var mw MainWindow
+
+	if err := (MainWindow{
+		AssignTo: &mw.MainWindow,
+		Title:    "Claude Desktop MCP Server Configuration",
+		MinSize:  Size{400, 300},
+		Size:     Size{500, 350},
+		Layout:   VBox{},
+		Children: []Widget{
+			Composite{
+				Layout: VBox{Margins: Margins{20, 20, 20, 20}},
+				Children: []Widget{
+					Label{
+						Text: "Select MCP Servers to configure in Claude Desktop:",
+						Font: Font{PointSize: 11, Bold: true},
+					},
+					VSeparator{},
+					CheckBox{
+						AssignTo: &mw.rplsCheckBox,
+						Text:     "RPLS (Rapport Labs Agent Gateway)",
+						Font:     Font{PointSize: 10},
+					},
+					Label{
+						Text: "  → https://agentgateway.damoa.rapportlabs.dance/mcp",
+						Font: Font{PointSize: 8},
+					},
+					VSpacer{Size: 10},
+					CheckBox{
+						AssignTo: &mw.queenitCheckBox,
+						Text:     "Queenit (Rapport Labs MCP)",
+						Font:     Font{PointSize: 10},
+					},
+					Label{
+						Text: "  → https://mcp.rapportlabs.kr/mcp",
+						Font: Font{PointSize: 8},
+					},
+					VSpacer{Size: 20},
+					PushButton{
+						Text: "Apply Configuration",
+						Font: Font{PointSize: 11, Bold: true},
+						OnClicked: func() {
+							mw.updateConfig()
+						},
+					},
+					VSpacer{Size: 10},
+					Label{
+						AssignTo: &mw.statusLabel,
+						Text:     "Ready to configure...",
+						Font:     Font{PointSize: 9},
+					},
+				},
+			},
+		},
+	}.Create()); err != nil {
+		panic(err)
+	}
+
+	// Load current state when the window opens
+	mw.loadCurrentState()
+
+	mw.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,10 @@
 module rapportlabs-mcp-helper
 
 go 1.21
+
+require (
+	github.com/lxn/walk v0.0.0-20210112085537-c389da54e794
+	github.com/lxn/win v0.0.0-20210218163916-a377121e959e // indirect
+	golang.org/x/sys v0.0.0-20201018230417-eeed37f84f13 // indirect
+	gopkg.in/Knetic/govaluate.v3 v3.0.0 // indirect
+)


### PR DESCRIPTION
## Summary
- Add Windows GUI application for configuring Claude Desktop MCP servers
- Support checkboxes for RPLS and Queenit MCP server selection
- Automatically manages claude_desktop_config.json in correct Windows location
- Self-contained executables with no dependencies

## Features
- Native Windows GUI with checkboxes for server selection
- Reads existing Claude Desktop configuration and shows current state  
- Updates %APPDATA%\Claude\claude_desktop_config.json with selected servers
- Creates JSON structure with proper npx mcp-remote commands
- Shows config file path and status messages
- Loads current configuration state on startup

## Configuration Output
When RPLS is checked:
```json
"rpls": {
  "command": "npx",
  "args": ["mcp-remote", "https://agentgateway.damoa.rapportlabs.dance/mcp"]
}
```

When Queenit is checked:
```json
"queenit": {
  "command": "npx", 
  "args": ["mcp-remote", "https://mcp.rapportlabs.kr/mcp"]
}
```

## Test plan
- [ ] Verify Windows GUI application builds successfully
- [ ] Test checkbox selection creates correct JSON configuration
- [ ] Verify config file is saved to correct Windows %APPDATA% location
- [ ] Test loading existing configuration state
- [ ] Confirm executables run without dependencies on Windows

🤖 Generated with [Claude Code](https://claude.ai/code)